### PR TITLE
VS Code (OSS)

### DIFF
--- a/Manifests/ManagedPreferencesApplications/com.microsoft.VSCode.plist
+++ b/Manifests/ManagedPreferencesApplications/com.microsoft.VSCode.plist
@@ -1,0 +1,178 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>pfm_app_url</key>
+	<string>https://code.visualstudio.com/</string>
+	<key>pfm_description</key>
+	<string>Visual Studio Code settings</string>
+	<key>pfm_documentation_url</key>
+	<string>https://code.visualstudio.com/docs</string>
+	<key>pfm_domain</key>
+	<string>com.microsoft.VSCode</string>
+	<key>pfm_format_version</key>
+	<integer>1</integer>
+	<key>pfm_last_modified</key>
+	<date>2023-10-01T10:35:00Z</date>
+	<key>pfm_platforms</key>
+	<array>
+		<string>macOS</string>
+	</array>
+	<key>pfm_subkeys</key>
+	<array>
+		<dict>
+			<key>pfm_default</key>
+			<string>Configures Visual Studio Code settings</string>
+			<key>pfm_description</key>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
+			<key>pfm_name</key>
+			<string>PayloadDescription</string>
+			<key>pfm_title</key>
+			<string>Payload Description</string>
+			<key>pfm_type</key>
+			<string>string</string>
+		</dict>
+		<dict>
+			<key>pfm_default</key>
+			<string>Visual Studio Code</string>
+			<key>pfm_description</key>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
+			<key>pfm_name</key>
+			<string>PayloadDisplayName</string>
+			<key>pfm_require</key>
+			<string>always</string>
+			<key>pfm_title</key>
+			<string>Payload Display Name</string>
+			<key>pfm_type</key>
+			<string>string</string>
+		</dict>
+		<dict>
+			<key>pfm_default</key>
+			<string>com.microsoft.VSCode</string>
+			<key>pfm_description</key>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile.
+During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
+			<key>pfm_name</key>
+			<string>PayloadIdentifier</string>
+			<key>pfm_require</key>
+			<string>always</string>
+			<key>pfm_title</key>
+			<string>Payload Identifier</string>
+			<key>pfm_type</key>
+			<string>string</string>
+		</dict>
+		<dict>
+			<key>pfm_default</key>
+			<string>com.microsoft.VSCode</string>
+			<key>pfm_description</key>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
+			<key>pfm_name</key>
+			<string>PayloadType</string>
+			<key>pfm_require</key>
+			<string>always</string>
+			<key>pfm_title</key>
+			<string>Payload Type</string>
+			<key>pfm_type</key>
+			<string>string</string>
+		</dict>
+		<dict>
+			<key>pfm_default</key>
+			<string></string>
+			<key>pfm_description</key>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs.
+During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
+			<key>pfm_format</key>
+			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
+			<key>pfm_name</key>
+			<string>PayloadUUID</string>
+			<key>pfm_require</key>
+			<string>always</string>
+			<key>pfm_title</key>
+			<string>Payload UUID</string>
+			<key>pfm_type</key>
+			<string>string</string>
+		</dict>
+		<dict>
+			<key>pfm_default</key>
+			<integer>1</integer>
+			<key>pfm_description</key>
+			<string>The version of this specific payload.</string>
+			<key>pfm_name</key>
+			<string>PayloadVersion</string>
+			<key>pfm_range_list</key>
+			<array>
+				<integer>1</integer>
+			</array>
+			<key>pfm_require</key>
+			<string>always</string>
+			<key>pfm_title</key>
+			<string>Payload Version</string>
+			<key>pfm_type</key>
+			<string>integer</string>
+		</dict>
+		<dict>
+			<key>pfm_description</key>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
+			<key>pfm_name</key>
+			<string>PayloadOrganization</string>
+			<key>pfm_title</key>
+			<string>Payload Organization</string>
+			<key>pfm_type</key>
+			<string>string</string>
+		</dict>
+		<dict>
+			<key>pfm_default</key>
+			<string>none</string>
+			<key>pfm_description</key>
+			<string>Update mode for Visual Studio Code</string>
+			<key>pfm_name</key>
+			<string>UpdateMode</string>
+			<key>pfm_title</key>
+			<string>Update Mode</string>
+			<key>pfm_type</key>
+			<string>string</string>
+			<key>pfm_range_list</key>
+			<array>
+				<string>none</string>
+				<string>manual</string>
+				<string>start</string>
+				<string>default</string>
+			</array>
+		</dict>
+		<dict>
+			<key>pfm_default</key>
+			<string></string>
+			<key>pfm_description</key>
+			<string>Allowed extensions for Visual Studio Code</string>
+			<key>pfm_name</key>
+			<string>AllowedExtensions</string>
+			<key>pfm_title</key>
+			<string>Allowed Extensions</string>
+			<key>pfm_type</key>
+			<string>string</string>
+		</dict>
+        <dict>
+            <key>pfm_default</key>
+            <integer>13</integer>
+            <key>pfm_description</key>
+            <string>Controls the font size in pixels for the Source Control input message</string>
+            <key>pfm_name</key>
+            <string>SCMInputFontSize</string>
+            <key>pfm_title</key>
+            <string>Source Control Input Font Size</string>
+            <key>pfm_type</key>
+            <string>integer</string>
+            <key>pfm_range_min</key>
+            <integer>8</integer>
+            <key>pfm_range_max</key>
+            <integer>36</integer>
+        </dict>
+	</array>
+	<key>pfm_title</key>
+	<string>Visual Studio Code</string>
+	<key>pfm_unique</key>
+	<true/>
+	<key>pfm_version</key>
+	<integer>1</integer>
+</dict>
+</plist>

--- a/Manifests/ManagedPreferencesApplications/com.visualstudio.code.oss.plist
+++ b/Manifests/ManagedPreferencesApplications/com.visualstudio.code.oss.plist
@@ -5,15 +5,15 @@
 	<key>pfm_app_url</key>
 	<string>https://code.visualstudio.com/</string>
 	<key>pfm_description</key>
-	<string>Visual Studio Code settings</string>
+	<string>Visual Studio Code Managed Settings</string>
 	<key>pfm_documentation_url</key>
 	<string>https://code.visualstudio.com/docs</string>
 	<key>pfm_domain</key>
-	<string>com.microsoft.VSCode</string>
+	<string>com.visualstudio.code.oss</string>
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2023-10-01T10:35:00Z</date>
+	<date>2025-02-14T10:00:00Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -22,7 +22,7 @@
 	<array>
 		<dict>
 			<key>pfm_default</key>
-			<string>Configures Visual Studio Code settings</string>
+			<string>Configure Visual Studio Code</string>
 			<key>pfm_description</key>
 			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
@@ -34,7 +34,7 @@
 		</dict>
 		<dict>
 			<key>pfm_default</key>
-			<string>Visual Studio Code</string>
+			<string>Visual Studio Code (OSS)</string>
 			<key>pfm_description</key>
 			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
@@ -48,7 +48,7 @@
 		</dict>
 		<dict>
 			<key>pfm_default</key>
-			<string>com.microsoft.VSCode</string>
+			<string>com.visualstudio.code.oss</string>
 			<key>pfm_description</key>
 			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile.
 During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
@@ -63,7 +63,7 @@ During a profile replacement, the system updates payloads with the same 'Payload
 		</dict>
 		<dict>
 			<key>pfm_default</key>
-			<string>com.microsoft.VSCode</string>
+			<string>com.visualstudio.code.oss</string>
 			<key>pfm_description</key>
 			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
@@ -124,7 +124,7 @@ During a profile replacement, the system updates payloads with the same 'Payload
 			<key>pfm_default</key>
 			<string>none</string>
 			<key>pfm_description</key>
-			<string>Update mode for Visual Studio Code</string>
+			<string>Update mode for Visual Studio Code (OSS)</string>
 			<key>pfm_name</key>
 			<string>UpdateMode</string>
 			<key>pfm_title</key>
@@ -143,7 +143,7 @@ During a profile replacement, the system updates payloads with the same 'Payload
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Allowed extensions for Visual Studio Code</string>
+			<string>Allowed extensions for Visual Studio Code (OSS)</string>
 			<key>pfm_name</key>
 			<string>AllowedExtensions</string>
 			<key>pfm_title</key>


### PR DESCRIPTION
- Clone this branch
- Install https://apps.apple.com/us/app/imazing-profile-editor/id1487860882?mt=12&ls=1
- In Imazing's settings under `Manifest` point to this repo on your local machine
- "VS Code" will now appear under "Available Application Domains"

NOTE: The profile is configured for OSS at the moment (VS Code built from source), and requires additional client setup